### PR TITLE
Claim copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Hugging Face
+   Copyright 2022, 2023 [text-generation-inference contributors](https://github.com/Preemo-Inc/text-generation-inference/graphs/contributors)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR replaces copyright holders Hugging Face with "text-generation-inference contributors".

The original copyright claim is not correct because external contributors did not sign an agreement to transfer copyright to Hugging Face.