### PR TITLE
Compilation fix: Correct method argument types in generation.rs and validation.rs

### DIFF
--- a/benchmark/src/generation.rs
+++ b/benchmark/src/generation.rs
@@ -218,6 +218,6 @@ fn create_sequence(sequence_length: u32, tokenizer: Tokenizer) -> String {
     encoding.truncate(sequence_length as usize, 0, TruncationDirection::Left);
     // Decode
     tokenizer
-        .decode(Vec::from(encoding.get_ids()), false)
+        .decode(encoding.get_ids().as_ref(), false)
         .unwrap()
 }

--- a/benchmark/src/generation.rs
+++ b/benchmark/src/generation.rs
@@ -218,6 +218,6 @@ fn create_sequence(sequence_length: u32, tokenizer: Tokenizer) -> String {
     encoding.truncate(sequence_length as usize, 0, TruncationDirection::Left);
     // Decode
     tokenizer
-        .decode(encoding.get_ids().as_ref(), false)
+        .decode(From::from(encoding.get_ids()), false)
         .unwrap()
 }

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -311,7 +311,7 @@ fn prepare_input(
             // truncate encoding and decode new inputs
             encoding.truncate(truncate, 0, TruncationDirection::Left);
             let inputs = tokenizer
-                .decode(encoding.get_ids().as_ref(), false)
+                .decode(From::from(encoding.get_ids()), false)
                 .map_err(|err| ValidationError::Tokenizer(err.to_string()))?;
             (inputs, encoding.len())
         }

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -311,7 +311,7 @@ fn prepare_input(
             // truncate encoding and decode new inputs
             encoding.truncate(truncate, 0, TruncationDirection::Left);
             let inputs = tokenizer
-                .decode(Vec::from(encoding.get_ids()), false)
+                .decode(encoding.get_ids().as_ref(), false)
                 .map_err(|err| ValidationError::Tokenizer(err.to_string()))?;
             (inputs, encoding.len())
         }


### PR DESCRIPTION
# What does this PR do?

In the `generation.rs` and `validation.rs` files, corrected the argument types passed to the `decode` method. Replaced `Vec<u32>` with `&[u32]` using the `as_ref()` method to match the expected argument types. This resolves the mismatched types compilation error during the Rust build process.

Fixes #9 

