### PR TITLE
fix: initialize v_cache to avoid NaNs

### DIFF
--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -44,6 +44,8 @@ class CacheManager:
         element_size = torch.tensor([], dtype=dtype).element_size()
         x = self.block_size // element_size
 
+        # v_cache can be initialized with any finite value, because the initial value would not take effect unless it is infinite or NaN. We use the max positive value to expose any portential bugs if the value is accidentally used in any computation.
+        self.v_cache_initial_value = torch.finfo(dtype).max
         self.kv_cache = [
             (
                 torch.empty(
@@ -110,6 +112,10 @@ class CacheManager:
             # Reset mask
             self.free_block_mask[block_indices] = 1
 
+            # Initialize v_cache to avoid NaNs
+            # See discussion at https://github.com/vllm-project/vllm/issues/641#issuecomment-1682619534
+            for _k_cache, v_cache in self.kv_cache:
+                v_cache[block_indices] = self.v_cache_initial_value
 
 @dataclass
 class FlashCausalLMBatch(Batch):


### PR DESCRIPTION
This PR fixes https://github.com/vllm-project/vllm/issues/641 by initializing v_cache.

The root cause is that the padding of v_cache will be used to dot-multiply by the padding of QK logits. Normally the dot product of v_cache padding and QK logits padding should be 0, because QK logits padding value is 0, therefore the result on the padded tokens should not contribute to the final result. However, when v_cache padding is NaN, the result would be NaN unexpectedly, because `0 * nan` is `nan`.

With the help of this PR, `v_cache` padding would become a finite value to avoid NaN result.